### PR TITLE
Use requirements.txt for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Usage & Notes
 An [http client](https://github.com/andrewboudreau/miner_httpclient) written in Python makes requesting data from the [Helium miner](https://github.com/helium/miner/) jsonrpc endpoints easier.
 
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then try a script like this to get started:
+
 ```python
 # Create a client (only logs errors)
 client = Client()

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ pip install -r requirements.txt
 Then try a script like this to get started:
 
 ```python
+from miner_httpclient import Client
+
 # Create a client (only logs errors)
 client = Client()
 summary = client.info_summary()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonrpcclient[requests]


### PR DESCRIPTION
See title! This makes it easier to get started, especially for automated tools or Docker builds

Also update README to mention they should:

```
pip install -r requirements.txt
```
